### PR TITLE
fix: Implement definitive and comprehensive fix for all Vercel build …

### DIFF
--- a/vite.config.cjs
+++ b/vite.config.cjs
@@ -1,15 +1,9 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
-import path from "path";
-import { fileURLToPath } from 'url';
-import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-export default defineConfig({
+const { defineConfig } = require("vite");
+const react = require("@vitejs/plugin-react");
+const path = require("path");
+module.exports = defineConfig({
   plugins: [
     react(),
-    runtimeErrorOverlay(),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
…failures

This commit resolves a persistent and multi-faceted Vercel build failure that manifested with several different error messages, including `vite: command not found`, `Could not resolve "./src/main.tsx"`, `failed to load config from vite.config.ts`, and an ESM/CJS incompatibility error.

The following cumulative changes have been made to create a robust and correct build configuration:

- The `build:client` script in `package.json` now uses `npx vite build` to ensure the Vite executable is always found in the Vercel CI/CD environment.
- The script `src` in `client/index.html` has been changed to a relative path (`./src/main.tsx`) to fix the Vite module resolution error.
- The `jsx` option in `tsconfig.json` has been set to `"react-jsx"`, which is the correct setting for a modern Vite + React project.
- The Vite configuration file has been converted from TypeScript (`.ts`) to CommonJS (`.cjs`) to prevent parsing issues in the build environment.
- The `@replit/vite-plugin-runtime-error-modal` has been removed from the Vite configuration, as it was an ESM-only package incompatible with the CommonJS config and not essential for production builds.

These cumulative changes ensure the build process is robust, correctly configured, and resilient to the specific behaviors of the Vercel platform.