### PR TITLE
fix: Implement definitive fix for all Vercel build failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "npm run build:client",
-    "build:client": "npx vite build",
+    "build:client": "vite build --config vite.config.cjs",
     "build:server": "esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",


### PR DESCRIPTION
This commit resolves a persistent and multi-faceted Vercel build failure that manifested with several different error messages, including `vite: command not found`, `Could not resolve "./src/main.tsx"`, `failed to load config from vite.config.ts`, and an ESM/CJS incompatibility error.

The following cumulative changes have been made to create a robust and correct build configuration:

- The `build:client` script in `package.json` is now `vite build --config vite.config.cjs` to directly call the local Vite executable and explicitly pass the config file, which is the most robust method for CI/CD environments.
- The Vite configuration file has been converted from TypeScript (`.ts`) to CommonJS (`.cjs`) to prevent parsing issues in the build environment.
- The `@replit/vite-plugin-runtime-error-modal` has been removed from the Vite configuration, as it was an ESM-only package incompatible with the CommonJS config and not essential for production builds.
- The script `src` in `client/index.html` has been changed to a relative path (`./src/main.tsx`) to fix the Vite module resolution error.
- The `jsx` option in `tsconfig.json` has been set to `"react-jsx"`, which is the correct setting for a modern Vite + React project.

These cumulative changes ensure the build process is robust, correctly configured, and resilient to the specific behaviors of the Vercel platform.