### PR TITLE
🐛 Fix: Enregistrer availabilityRouter pour corriger l'affichage des créneaux

### DIFF
--- a/server/routers.ts
+++ b/server/routers.ts
@@ -11,6 +11,7 @@ import { patientBookingRouter } from "./patientBookingRouter";
 import { bookingRouter } from "./bookingRouter";
 import { patientAppointmentsRouter } from "./patientAppointmentsRouter";
 import { calendarSyncRouter } from "./calendarSyncRouter";
+import { availabilityRouter } from "./availabilityRouter";
 import { availabilityOAuth2Router } from "./routers/availabilityOAuth2Router";
 import { appointmentOAuth2Router } from "./routers/appointmentOAuth2Router";
 import { publicProcedure, protectedProcedure, router } from "./_core/trpc";
@@ -27,6 +28,7 @@ export const appRouter = router({
   booking: bookingRouter, // Nouveau router pour la réservation simplifiée
   patientAppointments: patientAppointmentsRouter, // Nouveau router pour consulter/annuler les rendez-vous
   calendarSync: calendarSyncRouter, // Router pour la synchronisation bidirectionnelle avec Google Calendar
+  availability: availabilityRouter, // ✅ Router de disponibilités basé sur Google Calendar (événements "DISPONIBLE")
   availabilityOAuth2: availabilityOAuth2Router, // ✅ NOUVEAU: Disponibilités avec OAuth 2.0
   appointmentOAuth2: appointmentOAuth2Router, // ✅ NOUVEAU: Réservation avec OAuth 2.0
   auth: router({


### PR DESCRIPTION
### **User description**
## 🐛 Problème

L'application affichait des créneaux de disponibilité pour des jours **sans aucun événement DISPONIBLE** dans Google Calendar.

Par exemple, le **mercredi 7 janvier 2026** n'avait AUCUN événement dans le calendrier, mais l'application affichait quand même des créneaux de 9h à 18h.

## 🔍 Cause

Le router `availabilityRouter` qui gère les disponibilités basées sur les événements Google Calendar existait dans `server/availabilityRouter.ts` mais n'était **pas enregistré** dans `server/routers.ts`.

Le frontend appelait `trpc.availability.getAvailableSlots` mais ce endpoint n'existait pas, causant un comportement inattendu.

## ✅ Solution

1. **Import** de `availabilityRouter` dans `server/routers.ts`
2. **Enregistrement** du router sous la clé `availability` dans `appRouter`

## 📝 Comportement attendu après le fix

- ✅ **Mercredi 7 janvier 2026** : AUCUN créneau affiché (pas d'événement DISPONIBLE)
- ✅ **Seuls les jours avec événements DISPONIBLE** : Créneaux affichés
- ✅ **Créneaux pris automatiquement masqués**

## 🧪 Comment tester

1. Vérifier Google Calendar : Confirmer qu'il n'y a pas d'événement "DISPONIBLE" le mercredi 7 janvier 2026
2. Ouvrir l'application de réservation
3. Sélectionner le mercredi 7 janvier 2026
4. **Résultat attendu** : Message "Aucun créneau disponible pour cette date"

## 📊 Fichiers modifiés

- `server/routers.ts` : +2 lignes (import + enregistrement)

## 🔗 Refs

Fixes le bug de créneaux affichés sans événements DISPONIBLE dans Google Calendar.


___

### **PR Type**
Bug fix


___

### **Description**
- Register missing `availabilityRouter` in `appRouter` to fix availability endpoints

- Prevents displaying time slots for days without explicit "DISPONIBLE" events

- Ensures only days with Google Calendar availability events show available slots


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["availabilityRouter<br/>not registered"] -->|Fix: Import & Register| B["appRouter with<br/>availability endpoint"]
  B -->|Result| C["Correct slot display<br/>based on DISPONIBLE events"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routers.ts</strong><dd><code>Register availabilityRouter in appRouter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/routers.ts

<ul><li>Import <code>availabilityRouter</code> from <code>./availabilityRouter</code><br> <li> Register <code>availabilityRouter</code> in <code>appRouter</code> under the <code>availability</code> key<br> <li> Add explanatory comment indicating router handles Google Calendar <br>availability events</ul>


</details>


  </td>
  <td><a href="https://github.com/doriansarry47-creator/planning/pull/50/files#diff-f54ec88d37a3741d2274d99bff89ca6d84fd7b5cf005c67b557aa1debdfc69a7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles Fonctionnalités**
  * Ajout d'une nouvelle route de disponibilité à l'application, accessible aux utilisateurs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->